### PR TITLE
Upgrade `purescript` to v0.13.8

### DIFF
--- a/app/Command/DCE.hs
+++ b/app/Command/DCE.hs
@@ -45,7 +45,7 @@ import           Language.PureScript.DCE
 import qualified Language.PureScript.Errors.JSON as P
 import qualified Options.Applicative as Opts
 import qualified System.Console.ANSI as ANSI
-import           System.Directory (doesDirectoryExist, getCurrentDirectory)
+import           System.Directory (doesDirectoryExist, getCurrentDirectory, removeFile)
 import           System.Exit (exitFailure, exitSuccess)
 import           System.FilePath ((</>), (-<.>))
 import           System.FilePath.Glob (compile, globDir1)
@@ -352,7 +352,9 @@ dceCommand DCEOptions {..} = do
     -- more information than is present in `CoreFn.Module`).
     for_ mods $ \m -> lift $ do
       let mn = CoreFn.moduleName m
-      copyExterns mn "cbor" <|> copyExterns mn "json"
+      copyExterns mn "cbor" <|> do
+        removeFile (dceOutputDir </> (T.unpack $ P.runModuleName mn) </> "externs.cbor")
+        copyExterns mn "json"
     liftIO $ printWarningsAndErrors (P.optionsVerboseErrors dcePureScriptOptions) dceJsonErrors
         (suppressFFIErrors makeWarnings)
         (either (Left . suppressFFIErrors) Right makeErrors)

--- a/src/Language/PureScript/DCE/Constants.hs
+++ b/src/Language/PureScript/DCE/Constants.hs
@@ -7,46 +7,46 @@ import Prelude hiding (maybe)
 import Language.PureScript.Names
 
 unit :: ModuleName
-unit =  ModuleName [ProperName "Data", ProperName "Unit"] 
+unit =  ModuleName "Data.Unit"
 
 pattern Unit :: ModuleName
-pattern Unit = ModuleName [ProperName "Data", ProperName "Unit"]
+pattern Unit = ModuleName "Data.Unit"
 
 semigroup :: ModuleName
-semigroup = ModuleName [ProperName "Data", ProperName "Semigroup"] 
+semigroup = ModuleName "Data.Semigroup"
 
 maybeMod :: ModuleName
-maybeMod = ModuleName [ProperName "Data", ProperName "Maybe"] 
+maybeMod = ModuleName "Data.Maybe"
 
 pattern Semigroup :: ModuleName
-pattern Semigroup = ModuleName [ProperName "Data", ProperName "Semigroup"] 
+pattern Semigroup = ModuleName "Data.Semigroup"
 
 semiring :: ModuleName
-semiring = ModuleName [ProperName "Data", ProperName "Semiring"]
+semiring = ModuleName "Data.Semiring"
 
 pattern Ring :: ModuleName
-pattern Ring = ModuleName [ProperName "Data", ProperName "Ring"]
+pattern Ring = ModuleName "Data.Ring"
 
 ring :: ModuleName
-ring = ModuleName [ProperName "Data", ProperName "Ring"]
+ring = ModuleName "Data.Ring"
 
 pattern Semiring :: ModuleName
-pattern Semiring = ModuleName [ProperName "Data", ProperName "Semiring"]
+pattern Semiring = ModuleName "Data.Semiring"
 
 pattern HeytingAlgebra :: ModuleName
-pattern HeytingAlgebra = ModuleName [ProperName "Data", ProperName "HeytingAlgebra"]
+pattern HeytingAlgebra = ModuleName "Data.HeytingAlgebra"
 
 heytingAlgebra :: ModuleName
-heytingAlgebra = ModuleName [ProperName "Data", ProperName "HeytingAlgebra"]
+heytingAlgebra = ModuleName "Data.HeytingAlgebra"
 
 pattern UnsafeCoerce :: ModuleName
-pattern UnsafeCoerce = ModuleName [ProperName "Unsafe", ProperName "Coerce"]
+pattern UnsafeCoerce = ModuleName "Unsafe.Coerce"
 
 unsafeCoerce :: ModuleName
-unsafeCoerce = ModuleName [ProperName "Unsafe", ProperName "Coerce"]
+unsafeCoerce = ModuleName "Unsafe.Coerce"
 
 eqMod :: ModuleName
-eqMod = ModuleName [ProperName "Data", ProperName "Eq"]
+eqMod = ModuleName "Data.Eq"
 
 pattern Eq :: ModuleName
-pattern Eq = ModuleName [ProperName "Data", ProperName "Eq"]
+pattern Eq = ModuleName "Data.Eq"

--- a/src/Language/PureScript/DCE/Errors.hs
+++ b/src/Language/PureScript/DCE/Errors.hs
@@ -58,7 +58,7 @@ instance Read EntryPoint where
           Just (as, a)
             | not (null as)
             , True <- not (T.null a)
-            -> [(EntryPoint (mkQualified (Ident a) (ModuleName $ ProperName <$> as)), "")]
+            -> [(EntryPoint (mkQualified (Ident a) (ModuleName $ T.intercalate "." as)), "")]
           _ -> [(EntryParseError s, "")]
       "module"
         -> case unsnoc (T.splitOn "." (T.pack $ drop (idx + 1) s)) of
@@ -66,7 +66,7 @@ instance Read EntryPoint where
             | not (null as)
             , True <- not (T.null a)
             , True <- isUpper (T.head a)
-            -> [(EntryModule $ ModuleName $ ProperName <$> as ++ [a], "")]
+            -> [(EntryModule $ ModuleName $ T.intercalate "." (as ++ [a]), "")]
           _ -> [(EntryParseError s, "")]
       _ -> [(EntryParseError s, "")]
   readsPrec _ s
@@ -75,9 +75,9 @@ instance Read EntryPoint where
         | not (null as)
         , True <- not (T.null a)
         , True <- isLower (T.head a)
-          -> [(EntryPoint (mkQualified (Ident a) (ModuleName $ ProperName <$> as)), "")]
+          -> [(EntryPoint (mkQualified (Ident a) (ModuleName $ T.intercalate "." as)), "")]
         | True <- not (T.null a)
-          -> [(EntryModule $ ModuleName $ ProperName <$> as ++ [a], "")]
+          -> [(EntryModule $ ModuleName $ T.intercalate "." (as ++ [a]), "")]
         | otherwise
         -> [(EntryParseError s, "")]
       Nothing -> [(EntryParseError s, "")]

--- a/stack.yaml
+++ b/stack.yaml
@@ -8,7 +8,7 @@ packages:
 extra-deps:
 - happy-1.19.9
 - language-javascript-0.7.0.0
-- purescript-0.13.6
+- purescript-0.13.8
 - network-3.0.1.1
 - these-1.0.1
 - semialign-1

--- a/test/Generators.hs
+++ b/test/Generators.hs
@@ -6,7 +6,7 @@ import Data.List (foldl')
 import Data.String (IsString (..))
 import Test.QuickCheck
 
-import Language.PureScript.Names (Ident (..), ModuleName (..), ProperName (..), Qualified (..), moduleNameFromString)
+import Language.PureScript.Names (Ident (..), ModuleName (..), ProperName (..), Qualified (..))
 import Language.PureScript.PSString (PSString)
 import Language.PureScript.AST.SourcePos (SourceSpan (..), SourcePos (..))
 import Language.PureScript.AST (Literal (..))
@@ -38,9 +38,9 @@ genUnusedIdent = elements unusedIdents
 
 genModuleName :: Gen ModuleName
 genModuleName = elements
-  [ moduleNameFromString "Data.Eq"
-  , moduleNameFromString "Data.Array"
-  , moduleNameFromString "Data.Maybe"
+  [ ModuleName "Data.Eq"
+  , ModuleName "Data.Array"
+  , ModuleName "Data.Maybe"
   , C.semigroup
   , C.unsafeCoerce
   , C.unit
@@ -108,7 +108,7 @@ genExpr = sized go
       ]
 
 genCaseAlternative :: Gen (CaseAlternative Ann)
-genCaseAlternative = sized $ \n -> 
+genCaseAlternative = sized $ \n ->
   CaseAlternative <$> vectorOf n genBinder <*> genCaseAlternativeResult n
   where
   genCaseAlternativeResult :: Int -> Gen (Either [(Guard Ann, Expr Ann)] (Expr Ann))
@@ -169,7 +169,7 @@ prop_binderDistribution (PSBinder c) =
 
   depth :: Binder a -> Int
   depth NullBinder{}                        = 1
-  depth (LiteralBinder _ (ArrayLiteral bs)) = foldr (\b x -> depth b `max` x) 1 bs + 1 
+  depth (LiteralBinder _ (ArrayLiteral bs)) = foldr (\b x -> depth b `max` x) 1 bs + 1
   depth (LiteralBinder _ (ObjectLiteral o)) = foldr (\(_, b) x -> depth b `max` x) 0 o + 1
   depth LiteralBinder{}                     = 1
   depth VarBinder{}                         = 1

--- a/test/TestDCEEval.hs
+++ b/test/TestDCEEval.hs
@@ -39,10 +39,10 @@ eqBoolean :: Qualified Ident
 eqBoolean = Qualified (Just eqModName) (Ident "eqBoolean")
 
 eqModName :: ModuleName
-eqModName = ModuleName [ProperName "Data", ProperName "Eq"]
-          
+eqModName = ModuleName "Data.Eq"
+
 mn :: ModuleName
-mn = ModuleName [ProperName "Test"]
+mn = ModuleName "Test"
 
 mp :: FilePath
 mp = "src/Test.purs"
@@ -60,7 +60,7 @@ dceEvalExpr' e mods = case runWriterT $ dceEval ([testMod , eqMod , booleanMod ,
     ]
   eqMod = Module ss [] C.eqMod "" [] []
     [ Ident "refEq" ]
-    [ NonRec ann (Ident "eq")  
+    [ NonRec ann (Ident "eq")
         (Abs ann (Ident "dictEq")
           (Abs ann (Ident "x")
             (Abs ann (Ident "y")
@@ -73,9 +73,9 @@ dceEvalExpr' e mods = case runWriterT $ dceEval ([testMod , eqMod , booleanMod ,
         (Abs ann (Ident "eq")
           (Literal ann (ObjectLiteral [(mkString "eq", Var ann (Qualified Nothing (Ident "eq")))])))
     ]
-  booleanMod = Module ss [] (ModuleName [ProperName "Data", ProperName "Boolean"]) "" [] [] []
+  booleanMod = Module ss [] (ModuleName "Data.Boolean") "" [] [] []
     [ NonRec ann (Ident "otherwise") (Literal ann (BooleanLiteral True)) ]
-  arrayMod = Module ss [] (ModuleName [ProperName "Data", ProperName "Array"]) ""
+  arrayMod = Module ss [] (ModuleName "Data.Array") ""
     [] [] []
     [ NonRec ann (Ident "index")
         (Abs ann (Ident "as")
@@ -93,7 +93,7 @@ dceEvalExpr :: Expr Ann -> Either (DCEError 'Error) (Expr Ann)
 dceEvalExpr e = dceEvalExpr' e []
 
 prop_eval :: PSExpr Ann -> Property
-prop_eval (PSExpr g) = 
+prop_eval (PSExpr g) =
   let d  = exprDepth g
       g' = dceEvalExpr g
 
@@ -212,7 +212,7 @@ spec =
                         (Var ann (Qualified Nothing (Ident "x"))))
                       (Literal ann (BooleanLiteral True))
                     , Literal ann (CharLiteral 't'))
-                  , ( Var ann (Qualified (Just (ModuleName [ProperName "Data", ProperName "Boolean"])) (Ident "otherwise"))
+                  , ( Var ann (Qualified (Just (ModuleName "Data.Boolean")) (Ident "otherwise"))
                     , (Literal ann (CharLiteral 'f'))
                     )
                   ])
@@ -231,7 +231,7 @@ spec =
     specify "should evaluate exported literal" $ do
       let um :: Module Ann
           um = Module ss []
-            (ModuleName [ProperName "Utils"])
+            (ModuleName "Utils")
             "src/Utils.purs"
             []
             [Ident "isProduction"]
@@ -239,7 +239,7 @@ spec =
             [NonRec ann (Ident "isProduction") (Literal ann (BooleanLiteral True))]
           e :: Expr Ann
           e = Case ann
-            [ Var ann (Qualified (Just (ModuleName [ProperName "Utils"])) (Ident "isProduction"))]
+            [ Var ann (Qualified (Just (ModuleName "Utils")) (Ident "isProduction"))]
             [ CaseAlternative [LiteralBinder ann (BooleanLiteral True)] (Right (Literal ann (CharLiteral 't')))
             , CaseAlternative [LiteralBinder ann (BooleanLiteral False)] (Right (Literal ann (CharLiteral 'f')))
             ]
@@ -247,7 +247,7 @@ spec =
           mm = Module
             ss
             []
-            (ModuleName [ProperName "Main"])
+            (ModuleName "Main")
             "src/Main.purs"
             []
             []
@@ -270,11 +270,11 @@ spec =
       let e :: Expr Ann
           e = (App ann
                 (App ann
-                  (Var ann (Qualified (Just (ModuleName [ProperName "Data", ProperName "Array"])) (Ident "index")))
+                  (Var ann (Qualified (Just (ModuleName "Data.Array")) (Ident "index")))
                   (Literal ann (ArrayLiteral [Literal ann (CharLiteral 't')])))
                 (Literal ann (NumericLiteral (Left 0))))
       case dceEvalExpr e of
-        Right (App _ (Var _ (Qualified (Just (ModuleName [ProperName "Data", ProperName "Maybe"])) (Ident "Just"))) (Literal _ (CharLiteral 't'))) -> return ()
+        Right (App _ (Var _ (Qualified (Just (ModuleName "Data.Maybe")) (Ident "Just"))) (Literal _ (CharLiteral 't'))) -> return ()
         Right x -> assertFailure $ "unexpected expression:\n" ++ showExpr x
         Left err -> assertFailure $ "compilation error: " ++ show err
 
@@ -305,7 +305,7 @@ spec =
           Left err -> assertFailure $ "compilation error: " ++ show err
 
     context "Var inlining" $ do
-      let oModName = ModuleName [ProperName "Other"]
+      let oModName = ModuleName "Other"
           oMod = Module ss [] oModName "" [] [] []
             [ NonRec ann (Ident "o") $ Literal ann (ObjectLiteral [(mkString "a", Var ann (Qualified (Just C.eqMod) (Ident "eq"))) ])
             , NonRec ann (Ident "a") $ Literal ann (ArrayLiteral [ Var ann (Qualified (Just C.eqMod) (Ident "eq")) ])

--- a/zephyr.cabal
+++ b/zephyr.cabal
@@ -1,6 +1,6 @@
 version:             0.2.2
 name:                zephyr
-synopsis:           
+synopsis:
   Zephyr tree shaking for PureScript Language
 description:
   Tree shaking tool and partial evaluator for PureScript
@@ -59,7 +59,7 @@ library
     , Language.PureScript.DCE.Errors
     , Language.PureScript.DCE.Eval
     , Language.PureScript.DCE.Utils
-  build-depends:      
+  build-depends:
       aeson               >=1.0      && <1.5
     , ansi-terminal       >=0.7.1    && <0.11
     , base                >=4.8      && <5
@@ -69,7 +69,7 @@ library
     , formatting
     , language-javascript ^>=0.7
     , mtl                 >=2.1.0    && <2.3.0
-    , purescript          ^>=0.13.6
+    , purescript          ^>=0.13.8
     , safe                ^>=0.3.9
     , text
   default-language:    Haskell2010
@@ -108,7 +108,7 @@ executable zephyr
     , language-javascript  >=0.6.0.11 && <0.8
     , mtl                  >=2.1.0    && <2.3.0
     , optparse-applicative >=0.13.0
-    , purescript
+    , purescript           ^>=0.13.8
     , text
     , transformers         >=0.3.0    && <0.6
     , utf8-string          >=1        && <2
@@ -126,7 +126,7 @@ test-suite zephyr-test
     RecordWildCards
     TupleSections
   main-is: Main.hs
-  build-depends:      
+  build-depends:
       aeson                >=1.0      && <1.5
     , base                 >=4.8      && <5
     , base-compat          >=0.6.0
@@ -139,7 +139,7 @@ test-suite zephyr-test
     , mtl                  >=2.1.0    && <2.3.0
     , optparse-applicative >=0.13.0
     , process                            <1.7.0.0
-    , purescript
+    , purescript           ^>=0.13.8
     , QuickCheck           >=2.12.1
     , text
     , transformers         >=0.3.0    && <0.6

--- a/zephyr.cabal
+++ b/zephyr.cabal
@@ -67,7 +67,7 @@ library
     , boxes               ^>=0.1.4
     , containers
     , formatting
-    , language-javascript ^>=0.7
+    , language-javascript ==0.7.0.0
     , mtl                 >=2.1.0    && <2.3.0
     , purescript          ^>=0.13.8
     , safe                ^>=0.3.9
@@ -105,7 +105,7 @@ executable zephyr
     , filepath
     , formatting
     , Glob                 >=0.9      && <0.11
-    , language-javascript  >=0.6.0.11 && <0.8
+    , language-javascript  >=0.6.0.11 && <0.7.1
     , mtl                  >=2.1.0    && <2.3.0
     , optparse-applicative >=0.13.0
     , purescript           ^>=0.13.8
@@ -135,7 +135,7 @@ test-suite zephyr-test
     , hspec
     , hspec-core
     , HUnit
-    , language-javascript  >=0.6.0.11 && <0.8
+    , language-javascript  >=0.6.0.11 && <0.7.1
     , mtl                  >=2.1.0    && <2.3.0
     , optparse-applicative >=0.13.0
     , process                            <1.7.0.0


### PR DESCRIPTION
This PR updates `zephyr` to build against `purescript-0.13.8` and to copy externs.cbor files, fallbacking to externs.json files on error to support earlier versions of the compiler.

Fix https://github.com/coot/zephyr/issues/33.