### PR TITLE
C Libraries notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ To run tests
 cabal run zephyr-test
 ```
 
-# Non standard c libraries
+# C Libraries
 
-The released binaries are dynamically linked against `glibc`, if your system is using `musl` (or some other standard c library), you will need a `ghc` for that system and compile `zephyr` yourself.
+The released binaries are dynamically linked against `glibc`, so if your system is using `musl` (like Alpine Linux in `docker`) or another alternative C library, you will need to compile `zephyr` from source using `ghc` on that system.
 
 # Comments
 


### PR DESCRIPTION
Thanks for adding the section to the README.

I know it's a bit pedantic, don't think it's correct to assume `glibc` as a "standard" vs. "non-standard". There are [several Linux distros](https://wiki.musl-libc.org/projects-using-musl.html) running `musl` by default -- with Void and Alpine really sticking out. Alpine actually has more downloads on DockerHub than Ubuntu which, given this is a build tool, it seems significant. I don't code in C or have strong feeling towards libc-a vs libc-b, but I reworded the to specifically call out Alpine for its popularity as well as removing words about what's standard vs non-standard to avoid any flame wars.