### PR TITLE
Build against Purescript 0.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,10 +16,12 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-    - uses: actions/setup-haskell@v1.1.4
+    - name: Install Haskell
+      uses: haskell/actions/setup@v1
+      id: setup-haskell
       with:
-        ghc-version:   '8.6.5'
-        cabal-version: '3.2'
+        ghc-version: 8.10.7
+        cabal-version: 3.6.2.0
 
     - name: Setup cabal path (posix)
       if: matrix.os == 'ubuntu-latest' || matrix.os == 'macos-latest'
@@ -32,7 +34,7 @@ jobs:
 
     - uses: actions/setup-node@v1
       with:
-        node-version: '12'
+        node-version: '16'
     - name: Install bower
       run: npm install --global bower
     - name: Check versions
@@ -56,7 +58,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install zephyr's dependencies
       run: |
-        cabal install --install-method=copy --overwrite-policy=always purescript-0.13.8
+        cabal install --install-method=copy --overwrite-policy=always purescript
         cabal build --only-dependencies
 
     - name: Purs version (posix)

--- a/app/Command/Run.hs
+++ b/app/Command/Run.hs
@@ -26,13 +26,11 @@ import qualified Data.ByteString.Lazy as BSL
 import qualified Data.ByteString.Lazy.Char8 as BSL.Char8 (unpack)
 import qualified Data.ByteString.Lazy.UTF8 as BU8
 import           Data.Bool (bool)
-import           Data.Either (Either, lefts, rights, partitionEithers)
+import           Data.Either (lefts, rights, partitionEithers)
 import           Data.Foldable (for_, traverse_)
-import           Data.List (null)
 import qualified Data.Map as M
 import qualified Data.Set as S
 import           Data.Maybe (isNothing, listToMaybe)
-import           Data.Monoid ((<>))
 import           Data.Text (Text)
 import qualified Data.Text as T
 import qualified Data.Text.Lazy.Encoding as TE

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,6 +1,5 @@
 module Main (main) where
 
-import           Data.Monoid ((<>))
 import           Data.Version (showVersion)
 import qualified Options.Applicative as Opts
 import qualified Paths_zephyr as Paths

--- a/cabal.project
+++ b/cabal.project
@@ -1,2 +1,2 @@
-index-state: 2020-08-07T02:51:58Z
+index-state: 2021-11-25T21:23:01Z
 packages: .

--- a/src/Language/PureScript/DCE/CoreFn.hs
+++ b/src/Language/PureScript/DCE/CoreFn.hs
@@ -120,14 +120,14 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
 
           traverseExpr :: Expr Ann -> [Key]
           traverseExpr v@(Literal _ l) =
-            foldl
+            foldl'
               (++)
               (onExpr v)
               (map traverseExpr (extractLiteral l))
           traverseExpr v@Constructor {} = onExpr v
           traverseExpr v@(Accessor _ _ e1) = onExpr v ++ traverseExpr e1
           traverseExpr v@(ObjectUpdate _ obj vs) =
-            foldl
+            foldl'
               (++)
               (onExpr v ++ traverseExpr obj)
               (map (traverseExpr . snd) vs)
@@ -136,12 +136,12 @@ runDeadCodeElimination entryPoints modules = uncurry runModuleDeadCodeEliminatio
             onExpr v ++ traverseExpr e1 ++ traverseExpr e2
           traverseExpr v@(Var _ _) = onExpr v
           traverseExpr v@(Case _ vs alts) =
-            foldl
+            foldl'
               (++)
-              (foldl (++) (onExpr v) (map traverseExpr vs))
+              (foldl' (++) (onExpr v) (map traverseExpr vs))
               (map onCaseAlternative alts)
           traverseExpr v@(Let _ ds e1) =
-            foldl
+            foldl'
               (++)
               (onExpr v)
               (map onBind ds)

--- a/src/Language/PureScript/DCE/Errors.hs
+++ b/src/Language/PureScript/DCE/Errors.hs
@@ -20,7 +20,6 @@ import Prelude.Compat
 
 import           Data.Char (isLower, isUpper, isSpace)
 import           Data.List (dropWhileEnd, findIndex, intersperse)
-import           Data.Monoid ((<>))
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           Formatting (sformat, string, stext, (%))

--- a/src/Language/PureScript/DCE/Eval.hs
+++ b/src/Language/PureScript/DCE/Eval.hs
@@ -9,8 +9,7 @@ import Control.Monad
 import Control.Monad.Writer
 
 import Data.List (find)
-import Data.Maybe (Maybe(..), fromMaybe)
-import Data.Monoid (First(..))
+import Data.Maybe (fromMaybe)
 import qualified Data.Text as T
 import qualified Language.PureScript.DCE.Constants as C
 import Prelude.Compat hiding (mod)

--- a/src/Language/PureScript/DCE/Foreign.hs
+++ b/src/Language/PureScript/DCE/Foreign.hs
@@ -10,7 +10,6 @@ import           Prelude.Compat
 import           Control.Monad
 import           Data.Graph
 import           Data.Foldable (foldr')
-import           Data.List (any, elem, filter)
 import           Data.Maybe (catMaybes, fromMaybe, mapMaybe)
 import           Data.Text (Text)
 import qualified Data.Text as T

--- a/test/Test/CoreFn.hs
+++ b/test/Test/CoreFn.hs
@@ -3,7 +3,7 @@ module Test.CoreFn (spec)  where
 import Prelude ()
 import Prelude.Compat
 
-import Data.List (concatMap, foldl', intersect)
+import Data.List (foldl', intersect)
 import qualified Data.List as L
 
 import Language.PureScript.AST.Literals

--- a/test/Test/CoreLib.hs
+++ b/test/Test/CoreLib.hs
@@ -2,11 +2,9 @@ module Test.CoreLib (spec) where
 
 import           Prelude ()
 import           Prelude.Compat hiding (exp)
-import           Control.Monad (when)
 import           Control.Monad.Trans.Class
 import           Control.Monad.Except
-import           Data.Foldable (forM_)
-import           Data.Maybe (fromJust, isJust, maybe)
+import           Data.Maybe (fromJust, isJust)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           System.Directory (setCurrentDirectory)

--- a/test/Test/Karma.hs
+++ b/test/Test/Karma.hs
@@ -2,11 +2,8 @@ module Test.Karma (spec) where
 
 import           Prelude ()
 import           Prelude.Compat hiding (exp)
-import           Control.Monad (when)
 import           Control.Monad.Trans.Class
 import           Control.Monad.Except
-import           Data.List (init)
-import           Data.Foldable (forM_)
 import           Data.Text (Text)
 import qualified Data.Text as T
 import           System.Directory (setCurrentDirectory)

--- a/test/Test/Lib.hs
+++ b/test/Test/Lib.hs
@@ -42,6 +42,20 @@ libTests =
       <> " }\n"
       )
       True
+  , LibTest ["Literals.fromAnArray"] Nothing
+       ( " var lits = require('./dce-output/Literals');\n"
+      <> " if (lits.fromAnArray == null || lits.AStr == null || lits.AInt != null) {\n"
+      <> "    throw('Error')\n"
+      <> " }\n"
+      )
+      True
+  , LibTest ["Literals.fromAnObject"] Nothing
+       ( " var lits = require('./dce-output/Literals');\n"
+      <> " if (lits.fromAnObject == null || lits.AStr == null || lits.AInt != null) {\n"
+      <> "    throw('Error')\n"
+      <> " }\n"
+      )
+      True
   ]
 
 

--- a/test/Test/Lib.hs
+++ b/test/Test/Lib.hs
@@ -2,13 +2,10 @@ module Test.Lib (spec) where
 
 import           Prelude ()
 import           Prelude.Compat hiding (exp)
-import           Control.Monad (when)
 import           Control.Monad.Trans.Class
 import           Control.Monad.Except
-import           Data.Foldable (forM_)
 import           Data.Text (Text)
 import qualified Data.Text as T
-import           Data.Semigroup ((<>))
 import           System.Exit (ExitCode(..))
 import           System.Process (readProcessWithExitCode)
 import           Test.Hspec

--- a/test/Test/Utils.hs
+++ b/test/Test/Utils.hs
@@ -80,7 +80,6 @@ pursCompile coreLibTestRepo = do
           , "--codegen" , "corefn"
           , "bower_components/purescript-*/src/**/*.purs"
           , "src/**/*.purs"
-          , "test/**/*.purs"
           ]
           ""
     when (ecPurs /= ExitSuccess) (throwError $ PursError coreLibTestRepo ecPurs errPurs)

--- a/test/Test/Utils.hs
+++ b/test/Test/Utils.hs
@@ -5,10 +5,8 @@ module Test.Utils where
 import           Prelude ()
 import           Prelude.Compat hiding (exp)
 import           Control.Exception (bracket)
-import           Control.Monad (when)
 import           Control.Monad.Trans.Class
 import           Control.Monad.Except
-import           Data.List (last)
 import           Data.Maybe (fromMaybe)
 import           Data.Text (Text)
 import qualified Data.Text as T

--- a/test/lib-tests/bower.json
+++ b/test/lib-tests/bower.json
@@ -15,9 +15,9 @@
     "tests"
   ],
   "dependencies": {
-    "purescript-arrays": "^5.0.0",
-    "purescript-unsafe-coerce": "^4.0.0",
-    "purescript-prelude": "^4.1.0",
-    "purescript-maybe": "^4.0.0"
+    "purescript-arrays": "^6.0.0",
+    "purescript-unsafe-coerce": "^5.0.0",
+    "purescript-prelude": "^5.0.0",
+    "purescript-maybe": "^5.0.0"
   }
 }

--- a/test/lib-tests/src/Literals.purs
+++ b/test/lib-tests/src/Literals.purs
@@ -1,0 +1,11 @@
+module Literals where
+
+data A = AStr String | AInt Int
+
+fromAnArray :: Array A -> Array String
+fromAnArray [AStr str] = [str]
+fromAnArray _          = []
+
+fromAnObject :: { a :: A } -> { a :: Array String }
+fromAnObject { a : AStr str } = { a : [str] }
+fromAnObject _                = { a : [] }

--- a/zephyr.cabal
+++ b/zephyr.cabal
@@ -57,7 +57,6 @@ library
       -Wincomplete-uni-patterns
       -Wpartial-fields
       -Wredundant-constraints
-      -fmax-pmcheck-iterations=4000000
   exposed-modules:
       Language.PureScript.DCE
     , Language.PureScript.DCE.Constants
@@ -67,8 +66,8 @@ library
     , Language.PureScript.DCE.Eval
     , Language.PureScript.DCE.Utils
   build-depends:
-      aeson               >=1.0      && <1.5
-    , ansi-terminal       >=0.7.1    && <0.11
+      aeson               >=1.0      && <1.6
+    , ansi-terminal       >=0.7.1    && <0.12
     , base                >=4.8      && <5
     , base-compat         >=0.6.0
     , boxes               ^>=0.1.4
@@ -76,7 +75,8 @@ library
     , formatting
     , language-javascript >=0.7.0    && <0.8
     , mtl                 >=2.1.0    && <2.3.0
-    , purescript          ^>=0.13.8
+    , purescript          ^>=0.14.0
+    , purescript-cst
     , safe                ^>=0.3.9
     , text
   default-language:    Haskell2010
@@ -121,8 +121,9 @@ executable zephyr
     , Glob                 >=0.9      && <0.11
     , language-javascript
     , mtl                  >=2.1.0    && <2.3.0
-    , optparse-applicative >=0.13.0
-    , purescript           >=0.13.8
+    , optparse-applicative >=0.13.0   && <0.16
+    , purescript           ^>=0.14.0
+    , purescript-cst
     , text
     , transformers         >=0.3.0    && <0.6
     , utf8-string          >=1        && <2
@@ -159,9 +160,10 @@ test-suite zephyr-test
     , HUnit
     , language-javascript
     , mtl                  >=2.1.0    && <2.3.0
-    , optparse-applicative >=0.13.0
+    , optparse-applicative >=0.13.0   && <0.16
     , process
-    , purescript           ^>=0.13.8
+    , purescript           ^>=0.14
+    , purescript-cst
     , QuickCheck           >=2.12.1
     , text
     , transformers         >=0.3.0    && <0.6

--- a/zephyr.cabal
+++ b/zephyr.cabal
@@ -17,7 +17,7 @@ extra-source-files:
   ChangeLog.md
   README.md
 category:            Development
-tested-with:         ghc
+tested-with:         GHC==8.10.7
 
 flag test-with-stack
   description: use `stack exec zephyr` in tests


### PR DESCRIPTION
* Update purescript dep
* Add purescript-cst dep
* [Purescript#4148](https://github.com/purescript/purescript/pull/4148) removed the `everythingOnValues` function from `Language.PureScript.CoreFn.Traversals`. Refactor to include the necessary functionality locally.
* Update aeson dep

Fixes #64